### PR TITLE
Add a file permission option.

### DIFF
--- a/lib/Analytics/Consumer/File.php
+++ b/lib/Analytics/Consumer/File.php
@@ -20,7 +20,11 @@ class Analytics_Consumer_File extends Analytics_Consumer {
 
     try {
       $this->file_handle = fopen($options["filename"], "a");
-      chmod($options["filename"], 0777);
+      if (isset($options["filepermissions"])) {
+        chmod($options["filename"], $options["filepermissions"]);
+      } else {
+        chmod($options["filename"], 0777);
+      }
     } catch (Exception $e) {
       $this->handleError($e->getCode(), $e->getMessage());
     }

--- a/test/ConsumerFileTest.php
+++ b/test/ConsumerFileTest.php
@@ -50,9 +50,28 @@ class ConsumerFileTest extends PHPUnit_Framework_TestCase {
     $this->assertFalse($tracked);
   }
 
+  function testFileSecurity() {
+    $client = new Analytics_Client("testsecret",
+                          array("consumer" => "file",
+                                "filename" => $this->filename,
+                                "filepermissions" => 0700 ));
+
+    $tracked = $client->track("some_user", "File PHP Event");
+    $this->assertEquals(0700, (fileperms($this->filename) & 0777));
+  }
+
+  function testFileSecurityDefaults() {
+    $client = new Analytics_Client("testsecret",
+                          array("consumer" => "file",
+                                "filename" => $this->filename ));
+
+    $tracked = $client->track("some_user", "File PHP Event");
+    $this->assertEquals(0777, (fileperms($this->filename) & 0777));
+  }
+
   function checkWritten() {
     exec("wc -l " . $this->filename, $output);
-    $this->assertEquals($output[0], "1 " . $this->filename);
+    $this->assertEquals(trim($output[0]), "1 " . $this->filename);
     unlink($this->filename);
   }
 


### PR DESCRIPTION
Allow the user to pass an optional filepermissions octal parameter to the file consumer, which will be used instead of 0777 on the chmod().
