### PR TITLE
Don't try to array_combine two empty arrays

### DIFF
--- a/lib/Analytics/Client.php
+++ b/lib/Analytics/Client.php
@@ -87,7 +87,8 @@ class Analytics_Client {
       );
     }, $this->consumer);
 
-    return array_combine($this->getConsumerNames(), $returnValue);
+    $consumerNames = $this->getConsumerNames();
+    return $this->possiblyEmptyResults($consumerNames, $returnValue);
   }
 
   /**
@@ -119,7 +120,8 @@ class Analytics_Client {
     }, $this->consumer);
 
 
-    return array_combine($this->getConsumerNames(), $returnValue);
+    $consumerNames = $this->getConsumerNames();
+    return $this->possiblyEmptyResults($consumerNames, $returnValue);
   }
 
   public function getConsumerNames()
@@ -155,7 +157,8 @@ class Analytics_Client {
       );
     }, $this->consumer);
 
-    return array_combine($this->getConsumerNames(), $returnValue);
+    $consumerNames = $this->getConsumerNames();
+    return $this->possiblyEmptyResults($consumerNames, $returnValue);
   }
 
   /**
@@ -171,6 +174,18 @@ class Analytics_Client {
     return date("c", $timestamp);
   }
 
+  /**
+   * Return either an empty array or the combined result of key => value mappings of each of the arrays passed in
+   * This is necessary because `array_combine` causes a PHP fatal if both arrays are empty.
+   *
+   * @param $consumers The list of consumer names
+   * @param $results The result of calling each consumer with the event data
+   * @return array Either an empty array or the map of consumers to their results
+   */
+  private function possiblyEmptyResults($consumers, $results)
+  {
+    return empty($consumers) && empty($results) ? array() : array_combine($consumers, $results);
+  }
 
   /**
    * Add the segment.io context to the request


### PR DESCRIPTION
This fixes the case where there are no consumers attached to the analytics instance. Basically, `array_combine` requires that both arrays have a value, otherwise it throws an error. We shouldn't be calling `array_combine` with two empty arrays in the first place--the result will always be an empty array in that case--so this is a minor optimization, but it also prevents unit tests from failing (since they never have consumers attached).

ping @PascalZajac 
