### PR TITLE
silient warning, this is annoying

### DIFF
--- a/lib/Analytics/Consumer/Fornax.php
+++ b/lib/Analytics/Consumer/Fornax.php
@@ -30,8 +30,10 @@ class Analytics_Consumer_Fornax extends Analytics_Consumer {
     $options['filename'] = $this->getFilename();
 
     try {
-      $this->file_handle = fopen($options["filename"], "a");
-      chmod($options["filename"], $options["filepermissions"]);
+        $this->file_handle = @fopen($options["filename"], "a");
+        if ($this->file_handle) {
+            chmod($options["filename"], $options["filepermissions"]);
+        }
     } catch (\Exception $e) {
       $this->handleError($e->getCode(), $e->getMessage());
     }


### PR DESCRIPTION
AFAIK, neither `open` or `chmod` throw any exception in the default php implementation, but just in case that we have custom stream wrapper here, I left the `try..catch` block, just want to silence some very annoying warning during deployment. 