### PR TITLE
PLATFORM-700: add PHP 7.0 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - 5.4
-  - 5.3
+  - 5.6
+  - 7.0
 
 script: phpunit --colors test

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">=5.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "3.7.*"
+    "phpunit/phpunit": "5.5.*"
   },
   "autoload": {
     "files": ["lib/Analytics.php"]


### PR DESCRIPTION
- add PHP5.6 and PHP7.0 to Travis build matrix; remove older versions
- use PHPUnit 5.5.x, which is compatible with PHP7
